### PR TITLE
Spliting clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,32 @@
-VCS              := github.com
-ORGANIZATION     := gardener
-PROJECT          := node-controller-manager
-REPOSITORY       := $(VCS)/$(ORGANIZATION)/$(PROJECT)
-VERSION          := v0.1.0
-PACKAGES         := $(shell go list ./... | grep -vE '/vendor/|/pkg/test|/code-generator|/pkg/client|/pkg/openapi')
-LINT_FOLDERS     := $(shell echo $(PACKAGES) | sed "s|$(REPOSITORY)|.|g")
-BINARY_PATH      := $(REPOSITORY)/cmd/$(PROJECT)
+VCS              	:= github.com
+ORGANIZATION     	:= gardener
+PROJECT          	:= node-controller-manager
+REPOSITORY       	:= $(VCS)/$(ORGANIZATION)/$(PROJECT)
+VERSION          	:= v0.1.0
+PACKAGES         	:= $(shell go list ./... | grep -vE '/vendor/|/pkg/test|/code-generator|/pkg/client|/pkg/openapi')
+LINT_FOLDERS     	:= $(shell echo $(PACKAGES) | sed "s|$(REPOSITORY)|.|g")
+BINARY_PATH      	:= $(REPOSITORY)/cmd/$(PROJECT)
 
-IMAGE_REPOSITORY := kvmprashanth/node-controller-manager
-IMAGE_TAG        := v2
+IMAGE_REPOSITORY 	:= kvmprashanth/node-controller-manager
+IMAGE_TAG        	:= v2
 
-TYPES_FILES      := $(shell find pkg/apis -name types.go)
+TYPES_FILES      	:= $(shell find pkg/apis -name types.go)
 
-BINDIR           := bin
-GOBIN            := $(PWD)/bin
-PATH             := $(GOBIN):$(PATH)
-USER             := $(shell id -u -n)
+BINDIR           	:= bin
+GOBIN            	:= $(PWD)/bin
+PATH             	:= $(GOBIN):$(PATH)
+USER             	:= $(shell id -u -n)
+
+CONTROL_NAMESPACE 	:= default
+CONTROL_KUBECONFIG 	:= dev/target-kubeconfig.yaml
+TARGET_KUBECONFIG 	:= dev/target-kubeconfig.yaml
 
 export PATH
 export GOBIN
 
 .PHONY: dev
 dev:
-	@go run cmd/node-controller-manager/controller_manager.go --kubeconfig=dev/kubeconfig.yaml --kubeconfig-seed=dev/kubeconfig-seed.yaml --namespace=default --v=2
+	@go run cmd/node-controller-manager/controller_manager.go --control-kubeconfig=$(CONTROL_KUBECONFIG) --target-kubeconfig=$(TARGET_KUBECONFIG) --namespace=$(CONTROL_NAMESPACE) --v=2
 
 .PHONY: build
 build:

--- a/cmd/node-controller-manager/app/controllermanager.go
+++ b/cmd/node-controller-manager/app/controllermanager.go
@@ -39,7 +39,7 @@ import (
 
 	corecontroller "k8s.io/kubernetes/pkg/controller"
 
-	nodecontroller "github.com/gardener/node-controller-manager/pkg/controller"
+	machinecontroller "github.com/gardener/node-controller-manager/pkg/controller"
 
 	"github.com/gardener/node-controller-manager/cmd/node-controller-manager/app/options"
 	"github.com/golang/glog"
@@ -80,54 +80,68 @@ func Run(s *options.NCMServer) error {
 
 	var err error
 
-	//kubeconfig for the cluster for which node-controller-manager will create machines.
-	kubeconfig, err := clientcmd.BuildConfigFromFlags("", s.Kubeconfig)
+	//targetkubeconfig for the cluster for which node-controller-manager will create machines.
+	targetkubeconfig, err := clientcmd.BuildConfigFromFlags("", s.TargetKubeconfig)
 	if err != nil {
 		return err
 	}
 
-	kubeconfigSeed := kubeconfig
+	controlkubeconfig := targetkubeconfig
 
-	if s.KubeconfigSeed != "" {
-		//kubeconfig for the seedcluster where MachineCRDs are supposed to be registered.
-		kubeconfigSeed, err = clientcmd.BuildConfigFromFlags("", s.KubeconfigSeed)
+	if s.ControlKubeconfig != "" {
+		//targetkubeconfig for the seedcluster where MachineCRDs are supposed to be registered.
+		controlkubeconfig, err = clientcmd.BuildConfigFromFlags("", s.ControlKubeconfig)
 		if err != nil {
 			return err
-		}		
+		}
 	}
-	
-	// PROTOBUF WONT WORK
-	// kubeconfig.ContentConfig.ContentType = s.ContentType
-	// Override kubeconfig qps/burst settings from flags
-	kubeconfig.QPS = s.KubeAPIQPS
-	kubeconfigSeed.QPS = s.KubeAPIQPS
-	kubeconfig.Burst = int(s.KubeAPIBurst)
-	kubeconfigSeed.Burst = int(s.KubeAPIBurst)
 
-	kubeClientSeed, err := kubernetes.NewForConfig(
-		rest.AddUserAgent(kubeconfigSeed, "node-controller-manager"),
+	// PROTOBUF WONT WORK
+	// targetkubeconfig.ContentConfig.ContentType = s.ContentType
+	// Override targetkubeconfig qps/burst settings from flags
+	targetkubeconfig.QPS = s.KubeAPIQPS
+	controlkubeconfig.QPS = s.KubeAPIQPS
+	targetkubeconfig.Burst = int(s.KubeAPIBurst)
+	controlkubeconfig.Burst = int(s.KubeAPIBurst)
+
+	controlKubeClient, err := kubernetes.NewForConfig(
+		rest.AddUserAgent(controlkubeconfig, "node-controller-manager"),
 	)
 	if err != nil {
-		glog.Fatalf("Invalid API configuration for seed-kubeconfig: %v", err)
+		glog.Fatalf("Invalid API configuration for control kubeconfig: %v", err)
 	}
 
-	leaderElectionClient := kubernetes.NewForConfigOrDie(rest.AddUserAgent(kubeconfigSeed, "node-leader-election"))
+	leaderElectionClient := kubernetes.NewForConfigOrDie(rest.AddUserAgent(controlkubeconfig, "node-leader-election"))
 
 	glog.V(4).Info("Starting http server and mux")
 	go startHTTP(s)
 
-	recorder := createRecorder(kubeClientSeed)
+	recorder := createRecorder(controlKubeClient)
 
 	run := func(stop <-chan struct{}) {
-		nodeClientBuilder := nodecontroller.SimpleClientBuilder{
-			ClientConfig: kubeconfigSeed,
+		// Control plane client used to interact with machine APIs
+		controlMachineClientBuilder := machinecontroller.SimpleClientBuilder{
+			ClientConfig: controlkubeconfig,
+		}
+		// Control plane client used to interact with core kubernetes objects
+		controlCoreClientBuilder := corecontroller.SimpleControllerClientBuilder{
+			ClientConfig: controlkubeconfig,
+		}
+		// Target plane client used to interact with core kubernetes objects
+		targetCoreClientBuilder := corecontroller.SimpleControllerClientBuilder{
+			ClientConfig: targetkubeconfig,
 		}
 
-		coreClientBuilder := corecontroller.SimpleControllerClientBuilder{
-			ClientConfig: kubeconfig,
-		}
-
-		err := StartControllers(s, kubeconfig, nodeClientBuilder, coreClientBuilder, recorder, stop)
+		err := StartControllers(
+			s,
+			controlkubeconfig,
+			targetkubeconfig,
+			controlMachineClientBuilder,
+			controlCoreClientBuilder,
+			targetCoreClientBuilder,
+			recorder,
+			stop,
+		)
 		glog.Fatalf("error running controllers: %v", err)
 		panic("unreachable")
 
@@ -171,20 +185,30 @@ func Run(s *options.NCMServer) error {
 }
 
 func StartControllers(s *options.NCMServer,
-	coreKubeconfig *rest.Config,
-	nodeClientBuilder nodecontroller.ClientBuilder,
-	coreClientBuilder corecontroller.ControllerClientBuilder,
+	controlCoreKubeconfig *rest.Config,
+	targetCoreKubeconfig *rest.Config,
+	controlMachineClientBuilder machinecontroller.ClientBuilder,
+	controlCoreClientBuilder corecontroller.ControllerClientBuilder,
+	targetCoreClientBuilder corecontroller.ControllerClientBuilder,
 	recorder record.EventRecorder,
 	stop <-chan struct{}) error {
 
 	glog.V(5).Info("Getting available resources")
-	availableResources, err := getAvailableResources(coreClientBuilder)
+	availableResources, err := getAvailableResources(controlCoreClientBuilder)
 	if err != nil {
 		return err
 	}
 
-	coreKubeconfig = rest.AddUserAgent(coreKubeconfig, controllerManagerAgentName)
-	coreClient, err := kubernetes.NewForConfig(coreKubeconfig)
+	controlMachineClient := controlMachineClientBuilder.ClientOrDie(controllerManagerAgentName).MachineV1alpha1()
+
+	controlCoreKubeconfig = rest.AddUserAgent(controlCoreKubeconfig, controllerManagerAgentName)
+	controlCoreClient, err := kubernetes.NewForConfig(controlCoreKubeconfig)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	targetCoreKubeconfig = rest.AddUserAgent(targetCoreKubeconfig, controllerManagerAgentName)
+	targetCoreClient, err := kubernetes.NewForConfig(targetCoreKubeconfig)
 	if err != nil {
 		glog.Fatal(err)
 	}
@@ -192,34 +216,40 @@ func StartControllers(s *options.NCMServer,
 	if availableResources[awsGVR] || availableResources[azureGVR] || availableResources[gcpGVR] {
 		glog.V(5).Infof("Creating shared informers; resync interval: %v", s.MinResyncPeriod)
 
-		nodeInformerFactory := nodeinformers.NewFilteredSharedInformerFactory(
-			nodeClientBuilder.ClientOrDie("node-shared-informers"),
+		controlMachineInformerFactory := nodeinformers.NewFilteredSharedInformerFactory(
+			controlMachineClientBuilder.ClientOrDie("control-machine-shared-informers"),
 			s.MinResyncPeriod.Duration,
-			s.Namespace, 
+			s.Namespace,
 			nil,
 		)
 
-		coreInformerFactory := coreinformers.NewSharedInformerFactory(
-			coreClientBuilder.ClientOrDie("core-shared-informers"),
+		controlCoreInformerFactory := coreinformers.NewSharedInformerFactory(
+			controlCoreClientBuilder.ClientOrDie("control-core-shared-informers"),
+			s.MinResyncPeriod.Duration,
+		)
+
+		targetCoreInformerFactory := coreinformers.NewSharedInformerFactory(
+			targetCoreClientBuilder.ClientOrDie("target-core-shared-informers"),
 			s.MinResyncPeriod.Duration,
 		)
 
 		// All shared informers are v1alpha1 API level
-		nodeSharedInformers := nodeInformerFactory.Machine().V1alpha1()
+		machineSharedInformers := controlMachineInformerFactory.Machine().V1alpha1()
 
 		glog.V(5).Infof("Creating controllers...")
-		nodeController, err := nodecontroller.NewController(
+		nodeController, err := machinecontroller.NewController(
 			s.Namespace,
-			coreClient,
-			nodeClientBuilder.ClientOrDie(controllerManagerAgentName).MachineV1alpha1(),
-			coreInformerFactory.Core().V1().Secrets(),
-			coreInformerFactory.Core().V1().Nodes(),
-			nodeSharedInformers.AWSMachineClasses(),
-			nodeSharedInformers.AzureMachineClasses(),
-			nodeSharedInformers.GCPMachineClasses(),
-			nodeSharedInformers.Machines(),
-			nodeSharedInformers.MachineSets(),
-			nodeSharedInformers.MachineDeployments(),
+			controlMachineClient,
+			controlCoreClient,
+			targetCoreClient,
+			controlCoreInformerFactory.Core().V1().Secrets(),
+			targetCoreInformerFactory.Core().V1().Nodes(),
+			machineSharedInformers.AWSMachineClasses(),
+			machineSharedInformers.AzureMachineClasses(),
+			machineSharedInformers.GCPMachineClasses(),
+			machineSharedInformers.Machines(),
+			machineSharedInformers.MachineSets(),
+			machineSharedInformers.MachineDeployments(),
 			recorder,
 		)
 		if err != nil {
@@ -227,8 +257,9 @@ func StartControllers(s *options.NCMServer,
 		}
 		glog.V(1).Info("Starting shared informers")
 
-		coreInformerFactory.Start(stop)
-		nodeInformerFactory.Start(stop)
+		controlMachineInformerFactory.Start(stop)
+		controlCoreInformerFactory.Start(stop)
+		targetCoreInformerFactory.Start(stop)
 
 		glog.V(5).Info("Running controller")
 		go nodeController.Run(int(s.ConcurrentNodeSyncs), stop)

--- a/cmd/node-controller-manager/app/options/options.go
+++ b/cmd/node-controller-manager/app/options/options.go
@@ -40,8 +40,8 @@ import (
 type NCMServer struct {
 	nodeconfig.NodeControllerManagerConfiguration
 
-	Kubeconfig string
-	KubeconfigSeed string
+	ControlKubeconfig string
+	TargetKubeconfig  string
 }
 
 // NewNCMServer creates a new NCMServer with a default config.
@@ -52,7 +52,7 @@ func NewNCMServer() *NCMServer {
 		// Please keep them in sync when doing update.
 		NodeControllerManagerConfiguration: nodeconfig.NodeControllerManagerConfiguration{
 			Port:                    10258,
-			Namespace:               "default",	
+			Namespace:               "default",
 			Address:                 "0.0.0.0",
 			ConcurrentNodeSyncs:     5,
 			ContentType:             "application/vnd.kubernetes.protobuf",
@@ -78,9 +78,9 @@ func (s *NCMServer) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.BoolVar(&s.EnableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled")
-	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
-	fs.StringVar(&s.KubeconfigSeed, "kubeconfig-seed", "", "Path to seed cluster's kubeconfig file with authorization and master location information.")	
-	fs.StringVar(&s.Namespace, "namespace", s.Namespace, "Name of the namespace in seed cluster where controller would look for CRDs")
+	fs.StringVar(&s.TargetKubeconfig, "target-kubeconfig", s.TargetKubeconfig, "Path to kubeconfig file of the target cluster for which machines are to be managed")
+	fs.StringVar(&s.ControlKubeconfig, "control-kubeconfig", "", "Path to kubeconfig file of the control cluster where the node-controller-manager will run")
+	fs.StringVar(&s.Namespace, "namespace", s.Namespace, "Name of the namespace in control cluster where controller would look for CRDs and Kubernetes objects")
 	fs.StringVar(&s.ContentType, "kube-api-content-type", s.ContentType, "Content type of requests sent to apiserver.")
 	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", s.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver")
 	fs.Int32Var(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -61,8 +61,9 @@ $ kubectl apply -f kubernetes/crds.yaml
 
 ### Get started
 
-Create a `dev` directory and copy the Kubeconfig of the both kubernetes clusters used for development purposes to `dev/kubeconfig.yaml` and `dev/kubeconfig-seed.yaml`.
-
+- Create a `dev` directory. 
+- Copy the kubeconfig of kubernetes cluster where you wish to deploy the machines into `dev/target-kubeconfig.yaml`.
+- (optional) Copy the kubeconfig of kubernetes cluster from where you wish to manage the machines into `dev/control-kubeconfig.yaml`. If you do this, also update the `Makefile` variable CONTROL_KUBECONFIG to point to `dev/control-kubeconfig.yaml` and CONTROL_NAMESPACE to the namespace in which your controller watches over.
 - There is a rule dev in the `Makefile` which will automatically start the Node Controller Manager with development settings:
 
 ```bash
@@ -72,6 +73,9 @@ I1227 11:08:20.766085   55523 controller.go:247] Starting Node-controller-manage
 ```
 
 The Node Controller Manager should now be ready to manage the VMs in your kubernetes cluster.
+
+:warning: The file `dev/target-kubeconfig.yaml` points to the cluster whose nodes you want to manage. `dev/control-kubeconfig.yaml` points to the cluster from where you want to manage the nodes from. However, `dev/control-kubeconfig.yaml` is optional.
+
 
 ## Usage
 

--- a/kubernetes/aws-machine-class.yaml
+++ b/kubernetes/aws-machine-class.yaml
@@ -4,6 +4,7 @@ apiVersion: machine.sapcloud.io/v1alpha1
 kind: AWSMachineClass
 metadata:
   name: test-aws # Name of aws machine class goes here
+  namespace: default # Namespace in which the machine class is to be deployed
 spec:
   ami: ami-123456 # Amazon machine image name goes here
   region: eu-east-1 # Region in which machine is to be deployed

--- a/kubernetes/azure-machine-class.yaml
+++ b/kubernetes/azure-machine-class.yaml
@@ -4,7 +4,7 @@ apiVersion: machine.sapcloud.io/v1alpha1
 kind: AzureMachineClass
 metadata:
   name: test-azure # Name of aws machine class goes here
-  namespace: test
+  namespace: test # Namespace in which the machine class is to be deployed
 spec:
   location: "sample-location" # Azure location in which machine is to be deployed (Eg- NorthAmerica)
   resourceGroup: "sample-resource-group" # Name of the resource group to which the node should be bound

--- a/kubernetes/gcp-machine-class.yaml
+++ b/kubernetes/gcp-machine-class.yaml
@@ -4,7 +4,7 @@ apiVersion: machine.sapcloud.io/v1alpha1
 kind: GCPMachineClass
 metadata:
   name: test-gcp # Name of GCP machine class goes here
-  namespace: test
+  namespace: test # Namespace in which the machine class is to be deployed
 spec:
   canIpForward: true
   deletionProtection: false

--- a/kubernetes/machine-deployment.yaml
+++ b/kubernetes/machine-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   #paused: true [uncommment this when you want to pause]
   #rollbackTo:
     #revision: 0 [uncommment this when you want to rollback to previous version]
-  replicas: 2 # Number of healthy replicas that should always be healthy
+  replicas: 3 # Number of healthy replicas that should always be healthy
   minReadySeconds: 500 # Minimum time to wait for machine to be ready
   strategy: 
     type: RollingUpdate # Strategy for update RollingUpdate/Recreate

--- a/pkg/controller/awsmachineclass.go
+++ b/pkg/controller/awsmachineclass.go
@@ -86,7 +86,7 @@ func (c *controller) awsMachineClassUpdate(oldObj, newObj interface{}) {
 // reconcileClusterAWSMachineClassKey reconciles an AWSMachineClass due to controller resync
 // or an event on the awsMachineClass.
 func (c *controller) reconcileClusterAWSMachineClassKey(key string) error {
-	_ , name, err := cache.SplitMetaNamespaceKey(key)
+	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}
@@ -180,14 +180,14 @@ func (c *controller) deleteAWSMachineClassFinalizers(class *v1alpha1.AWSMachineC
 
 func (c *controller) updateAWSMachineClassFinalizers(class *v1alpha1.AWSMachineClass, finalizers []string) {
 	// Get the latest version of the class so that we can avoid conflicts
-	class, err := c.nodeClient.AWSMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
+	class, err := c.controlMachineClient.AWSMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
 	if err != nil {
 		return
 	}
 
 	clone := class.DeepCopy()
 	clone.Finalizers = finalizers
-	_, err = c.nodeClient.AWSMachineClasses(class.Namespace).Update(clone)
+	_, err = c.controlMachineClient.AWSMachineClasses(class.Namespace).Update(clone)
 	if err != nil {
 		// Keep retrying until update goes through
 		glog.Warning("Updated failed, retrying")

--- a/pkg/controller/azuremachineclass.go
+++ b/pkg/controller/azuremachineclass.go
@@ -86,13 +86,13 @@ func (c *controller) azureMachineClassUpdate(oldObj, newObj interface{}) {
 // reconcileClusterAzureMachineClassKey reconciles an AzureMachineClass due to controller resync
 // or an event on the azureMachineClass.
 func (c *controller) reconcileClusterAzureMachineClassKey(key string) error {
-	_ , name, err := cache.SplitMetaNamespaceKey(key)
+	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}
 
 	class, err := c.azureMachineClassLister.AzureMachineClasses(c.namespace).Get(name)
-	
+
 	if errors.IsNotFound(err) {
 		glog.Infof("%s %q: Not doing work because it has been deleted", AzureMachineClassKind, key)
 		return nil
@@ -181,14 +181,14 @@ func (c *controller) deleteAzureMachineClassFinalizers(class *v1alpha1.AzureMach
 
 func (c *controller) updateAzureMachineClassFinalizers(class *v1alpha1.AzureMachineClass, finalizers []string) {
 	// Get the latest version of the class so that we can avoid conflicts
-	class, err := c.nodeClient.AzureMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
+	class, err := c.controlMachineClient.AzureMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
 	if err != nil {
 		return
 	}
 
 	clone := class.DeepCopy()
 	clone.Finalizers = finalizers
-	_, err = c.nodeClient.AzureMachineClasses(class.Namespace).Update(clone)
+	_, err = c.controlMachineClient.AzureMachineClasses(class.Namespace).Update(clone)
 	if err != nil {
 		// Keep retrying until update goes through
 		glog.Warning("Updated failed, retrying")

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -410,15 +410,14 @@ type MachineSetControlInterface interface {
 
 // RealMachineSetControl is the default implementation of RSControllerInterface.
 type RealMachineSetControl struct {
-	NodeClient nodeclientset.MachineV1alpha1Interface
-	Recorder   record.EventRecorder
+	controlMachineClient nodeclientset.MachineV1alpha1Interface
+	Recorder             record.EventRecorder
 }
 
 var _ MachineSetControlInterface = &RealMachineSetControl{}
 
-
 func (r RealMachineSetControl) PatchMachineSet(namespace, name string, data []byte) error {
-	_, err := r.NodeClient.MachineSets(namespace).Patch(name, types.MergePatchType, data)
+	_, err := r.controlMachineClient.MachineSets(namespace).Patch(name, types.MergePatchType, data)
 	return err
 }
 
@@ -464,8 +463,8 @@ func validateControllerRef(controllerRef *metav1.OwnerReference) error {
 //--- For Machines ---//
 // RealmachineControl is the default implementation of machineControlInterface.
 type RealMachineControl struct {
-	NodeClient nodeclientset.MachineV1alpha1Interface
-	Recorder   record.EventRecorder
+	controlMachineClient nodeclientset.MachineV1alpha1Interface
+	Recorder             record.EventRecorder
 }
 
 var _ MachineControlInterface = &RealMachineControl{}
@@ -589,7 +588,7 @@ func (r RealMachineControl) createMachines(namespace string, template *v1alpha1.
 
 	//glog.Infof("2 : Printing Machine details : %+v", machine)
 
-	if newMachine, err := r.NodeClient.Machines(namespace).Create(machine); err != nil {
+	if newMachine, err := r.controlMachineClient.Machines(namespace).Create(machine); err != nil {
 		glog.Error(err)
 		//glog.Infof("3")
 		r.Recorder.Eventf(object, v1.EventTypeWarning, FailedCreateMachineReason, "Error creating: %v", err)
@@ -609,7 +608,7 @@ func (r RealMachineControl) createMachines(namespace string, template *v1alpha1.
 }
 
 func (r RealMachineControl) PatchMachine(namespace string, name string, data []byte) error {
-	_, err := r.NodeClient.Machines(namespace).Patch(name, types.MergePatchType, data)
+	_, err := r.controlMachineClient.Machines(namespace).Patch(name, types.MergePatchType, data)
 	return err
 }
 
@@ -620,7 +619,7 @@ func (r RealMachineControl) DeleteMachine(namespace string, machineID string, ob
 	}
 	glog.V(2).Infof("Controller %v deleting machine %v", accessor.GetName(), machineID)
 
-	if err := r.NodeClient.Machines(namespace).Delete(machineID, nil); err != nil {
+	if err := r.controlMachineClient.Machines(namespace).Delete(machineID, nil); err != nil {
 		r.Recorder.Eventf(object, v1.EventTypeWarning, FailedDeleteMachineReason, "Error deleting: %v", err)
 		return fmt.Errorf("unable to delete machines: %v", err)
 	} else {

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -245,7 +245,7 @@ func (dc *controller) deleteMachineToMachineDeployment(obj interface{}) {
 	glog.V(4).Infof("Machine %s deleted.", machine.Name)
 	if d := dc.getMachineDeploymentForMachine(machine); d != nil && d.Spec.Strategy.Type == v1alpha1.RecreateMachineDeploymentStrategyType {
 		// Sync if this Deployment now has no more Machines.
-		machineSets, err := ListMachineSets(d, IsListFromClient(dc.nodeClient))
+		machineSets, err := ListMachineSets(d, IsListFromClient(dc.controlMachineClient))
 		if err != nil {
 			return
 		}
@@ -311,7 +311,7 @@ func (dc *controller) getMachineDeploymentForMachine(machine *v1alpha1.Machine) 
 		// Not a Machine owned by a machine set.
 		return nil
 	}
-	is, err = dc.nodeClient.MachineSets(machine.Namespace).Get(controllerRef.Name, metav1.GetOptions{})
+	is, err = dc.controlMachineClient.MachineSets(machine.Namespace).Get(controllerRef.Name, metav1.GetOptions{})
 	if err != nil || is.UID != controllerRef.UID {
 		glog.V(4).Infof("Cannot get machineset %q for machine %q: %v", controllerRef.Name, machine.Name, err)
 		return nil
@@ -334,7 +334,7 @@ func (dc *controller) resolveDeploymentControllerRef(namespace string, controlle
 	if controllerRef.Kind != controllerKind.Kind {
 		return nil
 	}
-	d, err := dc.nodeClient.MachineDeployments(namespace).Get(controllerRef.Name, metav1.GetOptions{})
+	d, err := dc.controlMachineClient.MachineDeployments(namespace).Get(controllerRef.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil
 	}
@@ -380,7 +380,7 @@ func (dc *controller) getMachineSetsForMachineDeployment(d *v1alpha1.MachineDepl
 	// If any adoptions are attempted, we should first recheck for deletion with
 	// an uncached quorum read sometime after listing MachineSets (see #42639).
 	canAdoptFunc := RecheckDeletionTimestamp(func() (metav1.Object, error) {
-		fresh, err := dc.nodeClient.MachineDeployments(d.Namespace).Get(d.Name, metav1.GetOptions{})
+		fresh, err := dc.controlMachineClient.MachineDeployments(d.Namespace).Get(d.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -441,7 +441,7 @@ func (dc *controller) reconcileClusterMachineDeployment(key string) error {
 	if err != nil {
 		return err
 	}
-	deployment, err := dc.nodeClient.MachineDeployments(dc.namespace).Get(name, metav1.GetOptions{})
+	deployment, err := dc.controlMachineClient.MachineDeployments(dc.namespace).Get(name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		glog.V(2).Infof("Deployment %v has been deleted", key)
 		return nil
@@ -482,7 +482,7 @@ func (dc *controller) reconcileClusterMachineDeployment(key string) error {
 		dc.recorder.Eventf(d, v1.EventTypeWarning, "SelectingAll", "This deployment is selecting all machines. A non-empty selector is required.")
 		if d.Status.ObservedGeneration < d.Generation {
 			d.Status.ObservedGeneration = d.Generation
-			dc.nodeClient.MachineDeployments(d.Namespace).Update(d)
+			dc.controlMachineClient.MachineDeployments(d.Namespace).Update(d)
 		}
 		return nil
 	}
@@ -566,7 +566,7 @@ func (dc *controller) terminateMachineSets(machineSets []*v1alpha1.MachineSet, d
 			if machineSet.DeletionTimestamp != nil {
 				return
 			}
-			dc.nodeClient.MachineSets(machineSet.Namespace).Delete(machineSet.Name, nil)
+			dc.controlMachineClient.MachineSets(machineSet.Namespace).Delete(machineSet.Name, nil)
 		}(machineSet)
 	}
 	wg.Wait()
@@ -597,14 +597,14 @@ func (c *controller) deleteMachineDeploymentFinalizers(machineDeployment *v1alph
 
 func (c *controller) updateMachineDeploymentFinalizers(machineDeployment *v1alpha1.MachineDeployment, finalizers []string) {
 	// Get the latest version of the machineDeployment so that we can avoid conflicts
-	machineDeployment, err := c.nodeClient.MachineDeployments(machineDeployment.Namespace).Get(machineDeployment.Name, metav1.GetOptions{})
+	machineDeployment, err := c.controlMachineClient.MachineDeployments(machineDeployment.Namespace).Get(machineDeployment.Name, metav1.GetOptions{})
 	if err != nil {
 		return
 	}
 
 	clone := machineDeployment.DeepCopy()
 	clone.Finalizers = finalizers
-	_, err = c.nodeClient.MachineDeployments(machineDeployment.Namespace).Update(clone)
+	_, err = c.controlMachineClient.MachineDeployments(machineDeployment.Namespace).Update(clone)
 	if err != nil {
 		// Keep retrying until update goes through
 		glog.Warning("Updated failed, retrying")

--- a/pkg/controller/deployment_progress.go
+++ b/pkg/controller/deployment_progress.go
@@ -115,7 +115,7 @@ func (dc *controller) syncRolloutStatus(allISs []*v1alpha1.MachineSet, newIS *v1
 
 	newDeployment := d
 	newDeployment.Status = newStatus
-	_, err := dc.nodeClient.MachineDeployments(newDeployment.Namespace).Update(newDeployment)
+	_, err := dc.controlMachineClient.MachineDeployments(newDeployment.Namespace).Update(newDeployment)
 	return err
 }
 

--- a/pkg/controller/deployment_rollback.go
+++ b/pkg/controller/deployment_rollback.go
@@ -116,6 +116,6 @@ func (dc *controller) emitRollbackNormalEvent(d *v1alpha1.MachineDeployment, mes
 func (dc *controller) updateMachineDeploymentAndClearRollbackTo(d *v1alpha1.MachineDeployment) error {
 	glog.V(4).Infof("Cleans up rollbackTo of machine deployment %q", d.Name)
 	d.Spec.RollbackTo = nil
-	_, err := dc.nodeClient.MachineDeployments(d.Namespace).Update(d)
+	_, err := dc.controlMachineClient.MachineDeployments(d.Namespace).Update(d)
 	return err
 }

--- a/pkg/controller/drain.go
+++ b/pkg/controller/drain.go
@@ -488,7 +488,7 @@ func (o *DrainOptions) RunCordonOrUncordon(desired bool) error {
 	}
 	unsched := node.Spec.Unschedulable
 	if unsched == desired {
-		glog.Info("Already desired")
+		glog.V(3).Info("Already desired")
 	} else {
 		clone := node.DeepCopy()
 		clone.Spec.Unschedulable = desired

--- a/pkg/controller/gcpmachineclass.go
+++ b/pkg/controller/gcpmachineclass.go
@@ -86,7 +86,7 @@ func (c *controller) gcpMachineClassUpdate(oldObj, newObj interface{}) {
 // reconcileClusterGCPMachineClassKey reconciles an GCPMachineClass due to controller resync
 // or an event on the gcpMachineClass.
 func (c *controller) reconcileClusterGCPMachineClassKey(key string) error {
-	_ , name, err := cache.SplitMetaNamespaceKey(key)
+	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}
@@ -181,14 +181,14 @@ func (c *controller) deleteGCPMachineClassFinalizers(class *v1alpha1.GCPMachineC
 
 func (c *controller) updateGCPMachineClassFinalizers(class *v1alpha1.GCPMachineClass, finalizers []string) {
 	// Get the latest version of the class so that we can avoid conflicts
-	class, err := c.nodeClient.GCPMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
+	class, err := c.controlMachineClient.GCPMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
 	if err != nil {
 		return
 	}
 
 	clone := class.DeepCopy()
 	clone.Finalizers = finalizers
-	_, err = c.nodeClient.GCPMachineClasses(class.Namespace).Update(clone)
+	_, err = c.controlMachineClient.GCPMachineClasses(class.Namespace).Update(clone)
 	if err != nil {
 		// Keep retrying until update goes through
 		glog.Warning("Updated failed, retrying")

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -27,7 +27,7 @@ type NodeControllerManagerConfiguration struct {
 	metav1.TypeMeta
 
 	// namespace in seed cluster in which controller would look for the resources.
-	Namespace	string
+	Namespace string
 
 	// port is the port that the controller-manager's http service runs on.
 	Port int32


### PR DESCRIPTION
Splitting of kubeclients into 3 are done. I have tested it to the best of my knowledge (both with split kubeconfig and single kubeconfig) and it worked fine. I think it's safe to merge. We can further test the whole "seed_integration" PR before merging into the garden/master.

